### PR TITLE
Remove explicit passing of contexts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,22 +408,24 @@ assert ret == {'name': 'Mary', 'pythonista': True}
 
 ### Context
 
-Sometimes it's necessary to use values at bending time that are not on the
-source json and are not known at mapping time.
-For these cases there is the optional `context` argument to `bend()` function.
-Whatever you pass for the argument is can be used at bending time by the
-`Context()` bender.
-
+Sometimes it’s necessary to use values at bending time that are not on the
+source json and are not known at mapping time. In this case it’s easiest to wrap
+the source and the context inside a dictionary:
 
 ```python
-from jsonbender import bend, Context, S
+from jsonbender import bend, S
 
+source = S('source')
+context = S('context')
 MAPPING = {
-    'name': S('name'),
-    'age': (Context() >> S('year')) - S('birthyear'),
+    'name': source['name'],
+    'age': context['year'] - source['birthyear'],
 }
 source = {'name': 'Mary', 'birthyear': 1990}
-ret = bend(MAPPING, source, context={'year': 2016})
+ret = bend(MAPPING, {
+  'source': source,
+  'context': {'year': 2016},
+})
 assert ret == {'name': 'Mary', 'age': 26}
 ```
 

--- a/jsonbender/__init__.py
+++ b/jsonbender/__init__.py
@@ -1,4 +1,4 @@
-from jsonbender.core import Bender, Context, K, bend, BendingException
+from jsonbender.core import Bender, K, bend, BendingException
 from jsonbender.list_ops import FlatForall, Forall, Filter, Reduce
 from jsonbender.string_ops import Format
 from jsonbender.selectors import F, S, OptionalS

--- a/jsonbender/control_flow.py
+++ b/jsonbender/control_flow.py
@@ -25,10 +25,10 @@ class If(Bender):
         self.when_true = when_true
         self.when_false = when_false
 
-    def execute(self, val):
-        return (self.when_true(val)
-                if self.condition(val)
-                else self.when_false(val))
+    def bend(self, val):
+        return (self.when_true.bend(val)
+                if self.condition.bend(val)
+                else self.when_false.bend(val))
 
 
 class Alternation(Bender):
@@ -51,11 +51,11 @@ class Alternation(Bender):
     def __init__(self, *benders):
         self.benders = benders
 
-    def execute(self, source):
+    def bend(self, source):
         exc = ValueError()
         for bender in self.benders:
             try:
-                result = bender(source)
+                result = bender.bend(source)
             except LookupError as e:
                 exc = e
             else:
@@ -93,8 +93,8 @@ class Switch(Bender):
         self.cases = cases
         self.default = default
 
-    def execute(self, source):
-        key = self.key_bender(source)
+    def bend(self, source):
+        key = self.key_bender.bend(source)
         try:
             bender = self.cases[key]
         except LookupError:
@@ -103,5 +103,5 @@ class Switch(Bender):
             else:
                 raise
 
-        return bender(source)
+        return bender.bend(source)
 

--- a/jsonbender/core.py
+++ b/jsonbender/core.py
@@ -15,9 +15,6 @@ class Bender(object):
         pass
 
     def __call__(self, source):
-        return self.raw_execute(source)
-
-    def raw_execute(self, source):
         return self.execute(source)
 
     def execute(self, source):
@@ -86,8 +83,8 @@ class List(Bender):
     def __init__(self, list_):
         self.list = [benderify(v) for v in list_]
 
-    def raw_execute(self, source):
-        return [v.raw_execute(source) for v in self.list]
+    def execute(self, source):
+        return [v.execute(source) for v in self.list]
 
 
 class Dict(Bender):
@@ -96,11 +93,11 @@ class Dict(Bender):
     def __init__(self, dict_):
         self.dict = {k: benderify(v) for k, v in dict_.items()}
 
-    def raw_execute(self, source):
+    def execute(self, source):
         res = {}
         for k, v in self.dict.items():
             try:
-                res[k] = v.raw_execute(source)
+                res[k] = v.execute(source)
             except Exception as e:
                 m = 'Error for key {}: {}'.format(k, str(e))
                 raise BendingException(m)
@@ -120,8 +117,8 @@ class Compose(Bender):
         self._first = benderify(first)
         self._second = benderify(second)
 
-    def raw_execute(self, source):
-        return self._second.raw_execute(self._first.raw_execute(source))
+    def execute(self, source):
+        return self._second.execute(self._first.execute(source))
 
 
 class UnaryOperator(Bender):
@@ -142,7 +139,7 @@ class UnaryOperator(Bender):
     def op(self, v):
         raise NotImplementedError()
 
-    def raw_execute(self, source):
+    def execute(self, source):
         return self.op(self.bender(source))
 
 
@@ -175,7 +172,7 @@ class BinaryOperator(Bender):
     def op(self, v1, v2):
         raise NotImplementedError()
 
-    def raw_execute(self, source):
+    def execute(self, source):
         return self.op(self._bender1(source),
                        self._bender2(source))
 

--- a/jsonbender/list_ops.py
+++ b/jsonbender/list_ops.py
@@ -54,24 +54,6 @@ class Forall(ListOp):
     def op(self, func, vals):
         return list(map(func, vals))
 
-    @classmethod
-    def bend(cls, mapping):
-        """
-        Return a ForallBend instance that bends each element of the list with the
-        given mapping.
-
-        mapping: a JSONBender mapping as passed to the `bend()` function.
-
-        Example:
-        ```
-        source = [{'a': 23}, {'a': 27}]
-        bender = Forall.bend({'b': S('a')})
-        bender(source)  # -> [{'b': 23}, {'b': 27}]
-        ```
-
-        """
-        return ForallBend(mapping)
-
 
 class ForallBend(Forall):
     """

--- a/jsonbender/list_ops.py
+++ b/jsonbender/list_ops.py
@@ -32,10 +32,10 @@ class ListOp(Bender):
     def op(self, func, vals):
         raise NotImplementedError()
 
-    def execute(self, source):
+    def bend(self, source):
         # TODO: this is here for compatibility reasons
         if self._bender:
-            source = self._bender(source)
+            source = self._bender.bend(source)
         return self.op(self._func, source)
 
 
@@ -47,7 +47,7 @@ class Forall(ListOp):
 
     Example:
     ```
-    Forall(lambda i: i * 2)(range(5))  # -> [0, 2, 4, 6, 8]
+    Forall(lambda i: i * 2).bend(range(5))  # -> [0, 2, 4, 6, 8]
     ```
     """
 
@@ -68,9 +68,9 @@ class ForallBend(Forall):
         # remove this when ListOp also breaks retrocompatibility
         self._bender = None
 
-    def execute(self, source):
+    def bend(self, source):
         self._func = lambda v: bend(self._mapping, v)
-        return super().execute(source)
+        return super().bend(source)
 
 
 class Reduce(ListOp):
@@ -85,7 +85,7 @@ class Reduce(ListOp):
 
     Example: To sum a given list,
     ```
-    Reduce(lambda acc, i: acc + i)([1, 4, 6])  # -> 11
+    Reduce(lambda acc, i: acc + i).bend([1, 4, 6])  # -> 11
     ```
     """
     def op(self, func, vals):
@@ -103,7 +103,7 @@ class Filter(ListOp):
 
     Example:
     ```
-    Filter(lambda i: i % 2 == 0)(range(5))  # -> [0, 2, 4]
+    Filter(lambda i: i % 2 == 0).bend(range(5))  # -> [0, 2, 4]
     ```
     """
 
@@ -119,7 +119,7 @@ class FlatForall(ListOp):
 
     Example:
     ```
-    FlatForall(lambda x: [x-1, x+1])([1, 10, 100])  ->
+    FlatForall(lambda x: [x-1, x+1]).bend([1, 10, 100])  ->
          [[0, 2], [9, 11], [99, 101]] ->
          [0, 1, 9, 11, 99, 101]
     ```

--- a/jsonbender/list_ops.py
+++ b/jsonbender/list_ops.py
@@ -2,7 +2,7 @@ from functools import reduce
 from itertools import chain
 from warnings import warn
 
-from jsonbender.core import Bender, bend, Transport
+from jsonbender.core import Bender, bend
 
 
 class ListOp(Bender):
@@ -55,15 +55,12 @@ class Forall(ListOp):
         return list(map(func, vals))
 
     @classmethod
-    def bend(cls, mapping, context=None):
+    def bend(cls, mapping):
         """
         Return a ForallBend instance that bends each element of the list with the
         given mapping.
 
         mapping: a JSONBender mapping as passed to the `bend()` function.
-        context: optional. the context that will be passed to `bend()`.
-                 Note that if context is not passed, it defaults at bend-time
-                 to the one passed to the outer mapping.
 
         Example:
         ```
@@ -73,7 +70,7 @@ class Forall(ListOp):
         ```
 
         """
-        return ForallBend(mapping, context)
+        return ForallBend(mapping)
 
 
 class ForallBend(Forall):
@@ -81,24 +78,17 @@ class ForallBend(Forall):
     Bends each element of the list with given mapping and context.
 
     mapping: a JSONBender mapping as passed to the `bend()` function.
-    context: optional. the context that will be passed to `bend()`.
-             Note that if context is not passed, it defaults at bend-time
-             to the one passed to the outer mapping.
     """
 
     def __init__(self, mapping, context=None):
         self._mapping = mapping
-        self._context = context
         # TODO this is here for retrocompatibility reasons.
         # remove this when ListOp also breaks retrocompatibility
         self._bender = None
 
     def raw_execute(self, source):
-        transport = Transport.from_source(source)
-        context = self._context or transport.context
-        # ListOp.execute assumes the func is saved on self._func
-        self._func = lambda v: bend(self._mapping, v, context)
-        return Transport(self.execute(transport.value), transport.context)
+        self._func = lambda v: bend(self._mapping, v)
+        return self.execute(source)
 
 
 class Reduce(ListOp):

--- a/jsonbender/list_ops.py
+++ b/jsonbender/list_ops.py
@@ -86,9 +86,9 @@ class ForallBend(Forall):
         # remove this when ListOp also breaks retrocompatibility
         self._bender = None
 
-    def raw_execute(self, source):
+    def execute(self, source):
         self._func = lambda v: bend(self._mapping, v)
-        return self.execute(source)
+        return super().execute(source)
 
 
 class Reduce(ListOp):

--- a/jsonbender/selectors.py
+++ b/jsonbender/selectors.py
@@ -5,14 +5,14 @@ class S(Bender):
     """
     Selects a path of keys.
     Example:
-        S('a', 0, 'b').execute({'a': [{'b': 42}]}) -> 42
+        S('a', 0, 'b').bend({'a': [{'b': 42}]}) -> 42
     """
     def __init__(self, *path):
         if not path:
             raise ValueError('No path given')
         self._path = path
 
-    def execute(self, source):
+    def bend(self, source):
         for key in self._path:
             source = source[key]
         return source
@@ -31,16 +31,16 @@ class OptionalS(S):
 
     `default` defaults to None.
     Example:
-        OptionalS('a', 0, 'b', default=23).execute({'a': []}) -> 23
+        OptionalS('a', 0, 'b', default=23).bend({'a': []}) -> 23
     """
 
     def __init__(self, *path, **kwargs):
         self.default = kwargs.get('default')
         super(OptionalS, self).__init__(*path)
 
-    def execute(self, source):
+    def bend(self, source):
         try:
-            ret = super(OptionalS, self).execute(source)
+            ret = super(OptionalS, self).bend(source)
         except LookupError:
             return self.default
         else:
@@ -66,7 +66,7 @@ class F(Bender):
         self._args = args
         self._kwargs = kwargs
 
-    def execute(self, value):
+    def bend(self, value):
         return self._func(value, *self._args, **self._kwargs)
 
     def protect(self, protect_against=None):
@@ -90,7 +90,7 @@ class ProtectedF(F):
     Example:
     ```
         f = ProtectedF(lambda i: 1.0 / i, protect_against=0.0)
-        f.execute(0)  # -> 0
+        f.bend(0)  # -> 0
     ```
 
     """
@@ -98,10 +98,10 @@ class ProtectedF(F):
         self._protect_against = kwargs.pop('protect_against', None)
         super(ProtectedF, self).__init__(func, *args, **kwargs)
 
-    def execute(self, value):
+    def bend(self, value):
         if value == self._protect_against:
             return value
         else:
-            return super(ProtectedF, self).execute(value)
+            return super(ProtectedF, self).bend(value)
 
 

--- a/jsonbender/selectors.py
+++ b/jsonbender/selectors.py
@@ -1,7 +1,6 @@
 from jsonbender.core import Bender
 
 
-
 class S(Bender):
     """
     Selects a path of keys.

--- a/jsonbender/string_ops.py
+++ b/jsonbender/string_ops.py
@@ -13,7 +13,7 @@ class Format(Bender):
     ```
     fmt = Format('{} {} {last}', S('first'), S('second'), last=S('last'))
     source = {'first': 'Edsger', 'second': 'W.', 'last': 'Dijkstra'}
-    fmt.execute(source)  # -> 'Edsger W. Dijkstra'
+    fmt.bend(source)  # -> 'Edsger W. Dijkstra'
     ```
     """
     def __init__(self, format_string, *args, **kwargs):
@@ -21,9 +21,9 @@ class Format(Bender):
         self._positional_benders = args
         self._named_benders = kwargs
 
-    def execute(self, source):
-        args = [bender(source) for bender in self._positional_benders]
-        kwargs = {k: bender(source)
+    def bend(self, source):
+        args = [bender.bend(source) for bender in self._positional_benders]
+        kwargs = {k: bender.bend(source)
                   for k, bender in self._named_benders.items()}
         return self._format_str.format(*args, **kwargs)
 
@@ -35,19 +35,19 @@ class ProtectedFormat(Format):
     Examples:
         fmt = Format('{} {} {last}', S('first'), S('second'), last=S('last'))
         source = {'first': 'Edsger', 'second': 'W.', 'last': 'Dijkstra'}
-        fmt.execute(source)  # -> 'Edsger W. Dijkstra'
+        fmt.bend(source)  # -> 'Edsger W. Dijkstra'
 
         fmt = Format('{} {}', S('first'), S('second'))
         source = {'first': 'Edsger'}
-        fmt.execute(source)  # -> None
+        fmt.bend(source)  # -> None
     """
-    def execute(self, source):
+    def bend(self, source):
         # if any of the args to print are None, return None
         if any(
-            [bender(source) is None for bender in self._positional_benders] +
-            [bender(source) is None for bender in self._named_benders.values()]
+            [bender.bend(source) is None for bender in self._positional_benders] +
+            [bender.bend(source) is None for bender in self._named_benders.values()]
         ):
             # create an object with property value=None so it can be processed
             return None
         # else just behave normally
-        return super(ProtectedFormat, self).execute(source)
+        return super(ProtectedFormat, self).bend(source)

--- a/jsonbender/string_ops.py
+++ b/jsonbender/string_ops.py
@@ -21,7 +21,7 @@ class Format(Bender):
         self._positional_benders = args
         self._named_benders = kwargs
 
-    def raw_execute(self, source):
+    def execute(self, source):
         args = [bender(source) for bender in self._positional_benders]
         kwargs = {k: bender(source)
                   for k, bender in self._named_benders.items()}
@@ -41,7 +41,7 @@ class ProtectedFormat(Format):
         source = {'first': 'Edsger'}
         fmt.execute(source)  # -> None
     """
-    def raw_execute(self, source):
+    def execute(self, source):
         # if any of the args to print are None, return None
         if any(
             [bender(source) is None for bender in self._positional_benders] +
@@ -50,4 +50,4 @@ class ProtectedFormat(Format):
             # create an object with property value=None so it can be processed
             return None
         # else just behave normally
-        return super(ProtectedFormat, self).raw_execute(source)
+        return super(ProtectedFormat, self).execute(source)

--- a/jsonbender/string_ops.py
+++ b/jsonbender/string_ops.py
@@ -1,4 +1,4 @@
-from jsonbender.core import Bender, Transport
+from jsonbender.core import Bender
 
 
 class Format(Bender):
@@ -22,12 +22,10 @@ class Format(Bender):
         self._named_benders = kwargs
 
     def raw_execute(self, source):
-        transport = Transport.from_source(source)
         args = [bender(source) for bender in self._positional_benders]
         kwargs = {k: bender(source)
                   for k, bender in self._named_benders.items()}
-        value = self._format_str.format(*args, **kwargs)
-        return Transport(value, transport.context)
+        return self._format_str.format(*args, **kwargs)
 
 
 class ProtectedFormat(Format):
@@ -50,6 +48,6 @@ class ProtectedFormat(Format):
             [bender(source) is None for bender in self._named_benders.values()]
         ):
             # create an object with property value=None so it can be processed
-            return type(str('none_obj'), (object,), dict(value=None))
+            return None
         # else just behave normally
         return super(ProtectedFormat, self).raw_execute(source)

--- a/jsonbender/test.py
+++ b/jsonbender/test.py
@@ -1,5 +1,5 @@
 class BenderTestMixin(object):
     def assert_bender(self, bender, source, expected_value, msg=None):
-        got = bender(source)
+        got = bender.bend(source)
         assert got == expected_value
 

--- a/jsonbender/test.py
+++ b/jsonbender/test.py
@@ -1,10 +1,5 @@
-from jsonbender.core import Transport
-
-
 class BenderTestMixin(object):
-    def assert_bender(self, bender, source, expected_value,
-                      context=None, msg=None):
-        context = context or {}
-        got = bender(Transport(source, context))
-        self.assertEqual(got, expected_value, msg)
+    def assert_bender(self, bender, source, expected_value, msg=None):
+        got = bender(source)
+        assert got == expected_value
 

--- a/tests/test_control_flow.py
+++ b/tests/test_control_flow.py
@@ -34,7 +34,7 @@ class TestIf(BenderTestMixin, unittest.TestCase):
 
 class TestAlternation(BenderTestMixin, unittest.TestCase):
     def test_empty_benders(self):
-        self.assertRaises(ValueError, Alternation(), {})
+        self.assertRaises(ValueError, Alternation().bend, {})
 
     def test_matches(self):
         bender = Alternation(S(1), S(0), S('key1'))
@@ -43,8 +43,8 @@ class TestAlternation(BenderTestMixin, unittest.TestCase):
         self.assert_bender(bender, {'key1': 23}, 23)
 
     def test_no_match(self):
-        self.assertRaises(IndexError, Alternation(S(1)), [])
-        self.assertRaises(KeyError, Alternation(S(1)), {})
+        self.assertRaises(IndexError, Alternation(S(1)).bend, [])
+        self.assertRaises(KeyError, Alternation(S(1)).bend, {})
 
 
 class TestSwitch(BenderTestMixin, unittest.TestCase):
@@ -74,7 +74,7 @@ class TestSwitch(BenderTestMixin, unittest.TestCase):
                            'email@whatever.com')
 
     def test__no_match_without_default(self):
-        self.assertRaises(KeyError, Switch(S('key'), {}), {'key': None})
+        self.assertRaises(KeyError, Switch(S('key'), {}).bend, {'key': None})
 
 
 if __name__ == '__main__':

--- a/tests/test_control_flow.py
+++ b/tests/test_control_flow.py
@@ -1,7 +1,7 @@
 from operator import add
 import unittest
 
-from jsonbender import Context, K, S, bend
+from jsonbender import K, S, bend
 from jsonbender.control_flow import If, Alternation, Switch
 from jsonbender.test import BenderTestMixin
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,7 +3,7 @@ import unittest
 import sys
 
 from jsonbender import S, K, F
-from jsonbender.core import bend, BendingException, Context
+from jsonbender.core import bend, BendingException
 from jsonbender.test import BenderTestMixin
 
 
@@ -77,16 +77,6 @@ class TestBend(unittest.TestCase):
         self.assertDictEqual(bend(mapping, {}),
                              {'a': 'a const value', 'b': 123})
 
-    def test_context_shallow(self):
-        mapping = {'a': Context() >> S('b')}
-        res = bend(mapping, {}, context={'b': 23})
-        self.assertDictEqual(res, {'a': 23})
-
-    def test_context_deep(self):
-        mapping = {'a': [{'a': Context() >> S('b')}]}
-        res = bend(mapping, {}, context={'b': 23})
-        self.assertDictEqual(res, {'a': [{'a': 23}]})
-
 
 class TestOperators(unittest.TestCase, BenderTestMixin):
     def test_add(self):
@@ -105,13 +95,6 @@ class TestOperators(unittest.TestCase, BenderTestMixin):
     def test_neg(self):
         self.assert_bender(-K(1), None, -1)
         self.assert_bender(-K(-1), None, 1)
-
-    def test_op_with_context(self):
-        mapping = {'res': (Context() >> S('b')) - S('a')}
-        in_ = {'a': 23}
-        context = {'b': 27}
-        res = bend(mapping, in_, context=context)
-        self.assertEqual(res, {'res': 4})
 
     def test_eq(self):
         self.assert_bender(K(42) == K(42), None, True)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -90,7 +90,7 @@ class TestOperators(unittest.TestCase, BenderTestMixin):
 
     def test_div(self):
         self.assert_bender(K(4) / K(2), None, 2)
-        self.assertAlmostEqual((K(5) / K(2))(None), 2.5, 2)
+        self.assertAlmostEqual((K(5) / K(2)).bend(None), 2.5, 2)
 
     def test_neg(self):
         self.assert_bender(-K(1), None, -1)

--- a/tests/test_list_ops.py
+++ b/tests/test_list_ops.py
@@ -40,7 +40,7 @@ class TestReduce(ListOpTestCase):
 
     def test_empty_list(self):
         bender = Reduce(add)
-        self.assertRaises(ValueError, bender, [])
+        self.assertRaises(ValueError, bender.bend, [])
 
     def test_nonempty_list(self):
         self.assert_list_op(range(1, 5), add, 10)

--- a/tests/test_list_ops.py
+++ b/tests/test_list_ops.py
@@ -1,7 +1,7 @@
 from operator import add
 import unittest
 
-from jsonbender import Context, K, S, bend
+from jsonbender import K, S, bend
 from jsonbender.list_ops import Forall, FlatForall, Filter, ListOp, Reduce
 from jsonbender.test import BenderTestMixin
 
@@ -31,21 +31,6 @@ class TestForall(ListOpTestCase):
         self.assert_bender(self.cls.bend({'b': S('a')}),
                            [{'a': 23}, {'a': 27}],
                            [{'b': 23}, {'b': 27}])
-
-    def test_bend_with_context(self):
-        mapping = {'b': Context() >> S('c')}
-        context = {'c': 42}
-        self.assert_bender(self.cls.bend(mapping, context),
-                           [{}, {}],
-                           [{'b': 42}, {'b': 42}])
-
-    def test_bend_inherits_outer_context_by_default(self):
-        inner_mapping = {'val': Context()}
-        outer_mapping = {'a': S('items') >> Forall.bend(inner_mapping)}
-        source = {'items': range(3)}
-        got = bend(outer_mapping, source, context=27)
-        expected = {'a': [{'val': 27}, {'val': 27}, {'val': 27}]}
-        self.assertEqual(got, expected)
 
 
 class TestReduce(ListOpTestCase):

--- a/tests/test_list_ops.py
+++ b/tests/test_list_ops.py
@@ -2,7 +2,7 @@ from operator import add
 import unittest
 
 from jsonbender import K, S, bend
-from jsonbender.list_ops import Forall, FlatForall, Filter, ListOp, Reduce
+from jsonbender.list_ops import Forall, ForallBend, FlatForall, Filter, ListOp, Reduce
 from jsonbender.test import BenderTestMixin
 
 
@@ -27,10 +27,12 @@ class TestForall(ListOpTestCase):
         bender = self.cls(K([1]), lambda i: i)
         self.assert_bender(bender, {}, [1])
 
+
+class TestForallBend(ListOpTestCase):
+    cls = ForallBend
+
     def test_bend(self):
-        self.assert_bender(self.cls.bend({'b': S('a')}),
-                           [{'a': 23}, {'a': 27}],
-                           [{'b': 23}, {'b': 27}])
+        self.assert_list_op([{'a': 23}, {'a': 27}], {'b': S('a')}, [{'b': 23}, {'b': 27}])
 
 
 class TestReduce(ListOpTestCase):

--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -30,10 +30,10 @@ class TestS(unittest.TestCase, STestsMixin):
     selector_cls = S
 
     def test_shallow_missing_field(self):
-        self.assertRaises(KeyError, self.selector_cls('k'), {})
+        self.assertRaises(KeyError, self.selector_cls('k').bend, {})
 
     def test_deep_missing_field(self):
-        self.assertRaises(KeyError, self.selector_cls('k', 'k2'), {'k': {}})
+        self.assertRaises(KeyError, self.selector_cls('k', 'k2').bend, {'k': {}})
 
 
 class TestOptionalS(unittest.TestCase, STestsMixin):

--- a/tests/test_string_ops.py
+++ b/tests/test_string_ops.py
@@ -1,6 +1,6 @@
 import unittest
 
-from jsonbender import Context, K, S
+from jsonbender import K, S
 from jsonbender.string_ops import Format
 from jsonbender.test import BenderTestMixin
 
@@ -11,11 +11,6 @@ class TestFormat(unittest.TestCase, BenderTestMixin):
                         K('This'), K('is'), K('a'),
                         noun=K('test'))
         self.assert_bender(bender, None, 'This is a test.')
-
-    def test_with_context(self):
-        bender = Format('value: {}',  Context() >> S('b'))
-        self.assert_bender(bender, None, 'value: 23',
-                           context={'b': 23})
 
 
 if __name__ == '__main__':

--- a/tests/test_string_ops.py
+++ b/tests/test_string_ops.py
@@ -1,7 +1,7 @@
 import unittest
 
 from jsonbender import K, S
-from jsonbender.string_ops import Format
+from jsonbender.string_ops import Format, ProtectedFormat
 from jsonbender.test import BenderTestMixin
 
 
@@ -11,6 +11,16 @@ class TestFormat(unittest.TestCase, BenderTestMixin):
                         K('This'), K('is'), K('a'),
                         noun=K('test'))
         self.assert_bender(bender, None, 'This is a test.')
+
+
+class TestProtectedFormat(unittest.TestCase):
+    def test_format(self):
+        bender = ProtectedFormat(
+            '{} {} {} {noun}.',
+            K('This'), K('is'), K('a'), noun=S('noun').optional(),
+        )
+        assert bender({}) is None
+        assert bender({'noun': 'test'}) == 'This is a test.'
 
 
 if __name__ == '__main__':

--- a/tests/test_string_ops.py
+++ b/tests/test_string_ops.py
@@ -19,8 +19,8 @@ class TestProtectedFormat(unittest.TestCase):
             '{} {} {} {noun}.',
             K('This'), K('is'), K('a'), noun=S('noun').optional(),
         )
-        assert bender({}) is None
-        assert bender({'noun': 'test'}) == 'This is a test.'
+        assert bender.bend({}) is None
+        assert bender.bend({'noun': 'test'}) == 'This is a test.'
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- At least since #2 context can always be passed by adding an additional layer of dictionary. They don’t add to the expressiveness of our microlanguage.
- Removing contexts greatly simplifies the code and makes adding new operators easier.

```python
# before
benderify(mapping)(source, context)

#after
benderify(mapping).bend({'source': source, 'context': context})
```